### PR TITLE
Change composer.json vendor name to nenad.dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nenad/undertaker",
+    "name": "nenad.dev/undertaker",
     "description": "PHP counterpart for the undertaker project.",
     "type": "library",
     "require-dev": {


### PR DESCRIPTION
Welp, someone has `nenad/` on packagist, time to rebrand.